### PR TITLE
Updated Auto Tag workflow

### DIFF
--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   preparation:
     runs-on: ubuntu-latest
-    # This should allow parallel runs in a chain, e.g. OSS->Content->Experience->Commerce
+    # This should allow parallel runs in a chain, e.g. OSS->Headless->Experience->Commerce
     # whilst allowing Satis to process
     timeout-minutes: 30
 
@@ -42,12 +42,12 @@ jobs:
       # select(.version == "${{ env.V_VERSION }}"): filters the array to only include objects where the version property is equal to the value of the environment variable V_VERSION.
 
       # No need to validate for oss version in satis
-      - name: Validate satis for content version
+      - name: Validate satis for headless version
         if: github.event.repository.name == 'experience'
         env:
           SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
           SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
-          PARENT: ibexa/content
+          PARENT: ibexa/headless
           V_VERSION: v${{ inputs.version }}
         run: |
           for EXPONENTIAL_BACKOFF in {1..10}; do
@@ -144,7 +144,7 @@ jobs:
         run: jq '.require["ibexa/oss"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
       - name: Patch parent version for Experience
         if: github.event.repository.name == 'experience'
-        run: jq '.require["ibexa/content"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
+        run: jq '.require["ibexa/headless"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
       - name: Patch parent version for Commerce
         if: github.event.repository.name == 'commerce'
         run: jq '.require["ibexa/experience"] |= "${{ inputs.version }}"' composer.json | sponge composer.json


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | IBX-6405
| **Type**                                   | bug
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no
| **Doc needed**                       | no

This will properly set the parent to wait for experience meta in 4.6+ versions.

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [x] Checked that target branch is set correctly.
- [x] Asked for a review
