### PR TITLE
[Composer] Marked this package as replacement for ibexa/content

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,9 @@
     "repositories": [
         {"type": "composer", "url": "https://updates.ibexa.co"}
     ],
+    "replace": {
+        "ibexa/content": "*"
+    },
     "require": {
         "php": "^7.4 || ^8.0",
         "ibexa/oss": "~4.6.x-dev",


### PR DESCRIPTION
This might make the update process easier.

Right now Composer removes the ibexa/content package and unconfigures the recipe - which removes Ibexa entries from bundles.php

Hopefully with the `replace` section Composer/Flex will be smart enough to know that it's the same package - and leave the bundle entries in place.

#### Testing this PR

The only thing this PR can help is the upgrade process - and we will be able to verify this once 4.6.1 is released. I don't think it's possible to test this before merging/releasing it - unless you'd like to create a special fork and publish a tmp package on Packagist to verify this.