### PR TITLE
[GHA] Fixed patching headless-assets in "Create Tag" workflow

### DIFF
--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -25,12 +25,11 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Check for admin-ui-assets tag
-        if: github.event.repository.name == 'oss'
+      - name: Check for headless-assets tag
         uses: octokit/request-action@v2.x
         with:
           owner: ibexa
-          repo: admin-ui-assets
+          repo: headless-assets
           route: /repos/{owner}/{repo}/contents/package.json?ref=v${{ inputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
@@ -141,7 +140,9 @@ jobs:
         run: jq '.require["ibexa/admin-ui-assets"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
       - name: Patch parent version for Content
         if: github.event.repository.name == 'headless'
-        run: jq '.require["ibexa/oss"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
+        run: |
+          jq '.require["ibexa/headless-assets"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
+          jq '.require["ibexa/oss"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
       - name: Patch parent version for Experience
         if: github.event.repository.name == 'experience'
         run: jq '.require["ibexa/headless"] |= "${{ inputs.version }}"' composer.json | sponge composer.json

--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -135,20 +135,10 @@ jobs:
             rc*) $SET_STABILITY rc ;;
           esac;
 
-      - name: Patch parent version for OSS
-        if: github.event.repository.name == 'oss'
-        run: jq '.require["ibexa/admin-ui-assets"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
-      - name: Patch parent version for Content
-        if: github.event.repository.name == 'headless'
+      - name: Patch parent version for Headless
         run: |
           jq '.require["ibexa/headless-assets"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
           jq '.require["ibexa/oss"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
-      - name: Patch parent version for Experience
-        if: github.event.repository.name == 'experience'
-        run: jq '.require["ibexa/headless"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
-      - name: Patch parent version for Commerce
-        if: github.event.repository.name == 'commerce'
-        run: jq '.require["ibexa/experience"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
 
       # The effect of this jq command is to modify the require property of the input JSON object by using values from the $release object,
       # if they exist, to update the values of the keys in the require object.


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|


#### Description:

We missed patching `ibexa/headless-assets` for Ibexa Headless the same way we patch `ibexa/admin-ui-assets` for Ibexa OSS. Thus, all releases [kept referencing `~4.6.0@alpha`](https://github.com/ibexa/headless/blob/v4.6.18/composer.json#L40) which went unnoticed for quite some time.

Additionally, I've slightly cleaned up the "Create Tag" (`auto_tag.yml`) workflow removing steps that are not related to headless. I understand that this was done so the files in all editions are identical, however this case rather proves that they should not and are not identical, actually. Ideally, identical parts should just be extracted to a reusable workflow, but that's a bigger topic.

"Create Tag" dry run for this change:  https://github.com/ibexa/headless/actions/runs/13855563959/job/38771521954#step:12:48