### PR TITLE
IBX-10493: Included Redis 7.2 on CI

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
     regression-headless-setup1:
-        name: "PHP 7.4/Node 18/PostgreSQL 14.15/Varnish/Redis/Multirepository"
+        name: "PHP 7.4/Node 18/PostgreSQL 14.15/Varnish/Redis 7.2/Multirepository"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
             project-edition: "headless"
@@ -28,7 +28,7 @@ jobs:
             test-suite: "--profile=regression --suite=headless"
             test-setup-phase-1: "--profile=regression --suite=setup-headless --tags=~@part2 --mode=standard"
             test-setup-phase-2: "--profile=regression --suite=setup-headless --tags=@part2 --mode=standard"
-            setup: "doc/docker/base-dev.yml:doc/docker/db-postgresql.yml:doc/docker/varnish.yml:doc/docker/redis.yml:doc/docker/selenium.yml"
+            setup: "doc/docker/base-dev.yml:doc/docker/db-postgresql.yml:doc/docker/varnish.yml:doc/docker/redis7.2.yml:doc/docker/selenium.yml"
             send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
             multirepository: true
             php-image: "ghcr.io/ibexa/docker/php:7.4-node18"


### PR DESCRIPTION
**JIRA**: IBX-10493

Updated used Redis version.

Headless now has: Redis 7.2.

Related PRs:
https://github.com/ibexa/docker/pull/50
https://github.com/ibexa/ci-scripts/pull/111

TODO:
- [x] remove dependencies / temporary files